### PR TITLE
Treat custom libraries as installed and up to date

### DIFF
--- a/src/librarymanager/libraryManager.ts
+++ b/src/librarymanager/libraryManager.ts
@@ -23,12 +23,12 @@ class LibraryQP implements vscode.QuickPickItem {
   public constructor(b: Library, p: Library) {
     this.bundleLib = b;
     this.projectLib = p;
-    this.label = b.name;
+    this.label = b?.name || p.name;
 
     if(p === null) {
       this.op = "install";
       this.description = `Install version ${b.version}`;
-    } else if(b.version !== p.version) {
+    } else if(b && b.version !== p.version) {
       this.op = "update";
       this.description = `Update from v${p.version} to v${b.version}`;
     } else {


### PR DESCRIPTION
Extension was failing when a library was present that was not provided by CircuitPython.
May not be the correct fix, but works for now.